### PR TITLE
Add random jitter to sleep times

### DIFF
--- a/amdahl/amdahl.py
+++ b/amdahl/amdahl.py
@@ -44,7 +44,7 @@ def do_work(work_time=30, parallel_proportion=0.8, comm=MPI.COMM_WORLD, terse=Fa
 
         if not terse:
             sys.stdout.write(
-                "Doing %f seconds of 'work' on %s processor %s,\n"
+                "Doing %f seconds of 'work' on %s processor%s,\n"
                 " which should take %f seconds with %f parallel"
                 " proportion of the workload.\n\n"
                 % (

--- a/amdahl/amdahl.py
+++ b/amdahl/amdahl.py
@@ -160,6 +160,7 @@ def parse_command_line():
 def amdahl():
     """Amdahl's law illustrator (with fake work)"""
     rank = MPI.COMM_WORLD.Get_rank()
+    # Ensure that all ranks use a guaranteed unique seed when generating random numbers
     random.seed(int(time.time()) + rank)
     # Only the root process handles the command line arguments
     if rank == 0:

--- a/amdahl/amdahl.py
+++ b/amdahl/amdahl.py
@@ -96,8 +96,15 @@ def random_jitter(x, sigma=0.2):
     """
     Apply a random offset of ±20% to a value
     """
-    y_min = x - sigma
-    return y_min + 2 * sigma * random.random()
+    # Make sure sigma is between 0 and 1
+    if sigma < 0 or sigma > 1 :
+        sys.stdout.write(
+            "Illegal value for sigma (%f), should be a float between 0 and 1!\n" % sigma
+            "Using 0.2 instead..."
+        sigma = 0.2
+    # random() returns a float between 0 and 1, map between -sigma and +sigma
+    jitter_percent = sigma * ((random.random() * 2) - 1)
+    return (1 + jitter_percent) * x
 
 
 def parse_command_line():

--- a/amdahl/amdahl.py
+++ b/amdahl/amdahl.py
@@ -19,7 +19,11 @@ parallelizable proportion.
 """
 
 
-def do_work(work_time=30, parallel_proportion=0.8, comm=MPI.COMM_WORLD, terse=False, exact=False):
+def do_work(work_time=30,
+            parallel_proportion=0.8,
+            comm=MPI.COMM_WORLD,
+            terse=False,
+            exact=False):
     # How many MPI ranks (cores) are we?
     size = comm.Get_size()
     # Who am I in that set of ranks?
@@ -65,9 +69,9 @@ def do_work(work_time=30, parallel_proportion=0.8, comm=MPI.COMM_WORLD, terse=Fa
     else:
         parallel_sleep_time = None
 
-    # Tell all processes how much work they need to do using 'bcast' to broadcast
-    # (this also creates an implicit barrier, blocking processes until they receive
-    # the value)
+    # Tell all processes how much work they need to do using 'bcast' to
+    # broadcast (this also creates an implicit barrier, blocking processes
+    # until they receive the value)
     parallel_sleep_time = comm.bcast(parallel_sleep_time, root=0)
 
     if not exact:
@@ -75,10 +79,11 @@ def do_work(work_time=30, parallel_proportion=0.8, comm=MPI.COMM_WORLD, terse=Fa
 
     terse = comm.bcast(terse, root=0)
 
-    # This is where everyone pretends to do work (while really we are just sleeping)
+    # This is where everyone pretends to do work (really we are just sleeping)
     if not terse:
         sys.stdout.write(
-            "  Hello, World! I am process %d of %d on %s. I will do parallel 'work' for "
+            "  Hello, World! "
+            "I am process %d of %d on %s. I will do parallel 'work' for "
             "%f seconds.\n" % (rank, size, name, parallel_sleep_time)
         )
     time.sleep(parallel_sleep_time)
@@ -177,7 +182,8 @@ def amdahl():
             )
         else:
             sys.stdout.write(
-                "\nTotal execution time (according to rank 0): %f seconds\n" % (end - start)
+                "\nTotal execution time (according to rank 0): "
+                "%f seconds\n" % (end - start)
             )
     else:
         do_work()


### PR DESCRIPTION
C'mon, we can't have a _perfect_ plot, that's cheating!!!

This PR introduces random jitter to the sleep times called by each process, in serial and parallel, up to ±20%. This little bit of noise makes the results a skosh more realistic, without significantly increasing code complexity.

A couple of minor typos are also fixed, and lines are wrapped to fit within one GitHub diff frame.