### PR TITLE
Clarify comments & flow, add hostname

### DIFF
--- a/amdahl/amdahl.py
+++ b/amdahl/amdahl.py
@@ -127,6 +127,7 @@ def do_work(work_time=30,
     if rank == 0:
         # This function returns a "dict" containing named values.
         return {
+            'host': hostname,
             'nproc': num_mpi_ranks,
             'serial_work': serial_sleep_time,
             'parallel_work': parallel_sleep_time


### PR DESCRIPTION
This PR revises the Amdahl program with improved comment strings, clarification to the parallel workflow (get args first, then do work, then output), and records the host on which it ran in the "terse" output.